### PR TITLE
Add variable to override listen address

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,10 +15,11 @@ Role Variables
 The variables that can be passed to this role and a brief description about
 them are as follows:
 
-	memcached_port: 11211           # The port in which memcached server should be listening
-	memcached_max_conn: 1024        # The number of max concurrent connections it shoud accept
-	memcached_cache_size: 64        # The cache size
-	memcached_fs_file_max: 756024   # The kernel paramter for max number of file handles
+    memcached_port: 11211              # The port in which memcached server should be listening
+    memcached_listen_address: 0.0.0.0  # The IP address to listen on
+    memcached_max_conn: 1024           # The number of max concurrent connections it should accept
+    memcached_cache_size: 64           # The cache size
+    memcached_fs_file_max: 756024      # The kernel parameter for max number of file handles
 
 Example
 -------

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,8 @@
 ---
 
 memcached_port: 11211
+memcached_listen_address: 0.0.0.0
 memcached_max_conn: 1024
 memcached_cache_size: 64
 memcached_fs_file_max: 756024
-memcached_listen_address: 0.0.0.0
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,4 +4,5 @@ memcached_port: 11211
 memcached_max_conn: 1024
 memcached_cache_size: 64
 memcached_fs_file_max: 756024
+memcached_listen_address: 0.0.0.0
 

--- a/templates/memcached_debian.j2
+++ b/templates/memcached_debian.j2
@@ -32,7 +32,7 @@ logfile /var/log/memcached.log
 # Specify which IP address to listen on. The default is to listen on all IP addresses
 # This parameter is one of the only security measures that memcached has, so make sure
 # it's listening on a firewalled interface.
--l 0.0.0.0
+-l {{ memcached_listen_address }}
 
 # Limit the number of simultaneous incoming connections. The daemon default is 1024
 -c {{ memcached_max_conn }}

--- a/templates/memcached_redhat.j2
+++ b/templates/memcached_redhat.j2
@@ -2,4 +2,4 @@ PORT={{ memcached_port }}
 USER="memcached"
 MAXCONN={{ memcached_max_conn }}
 CACHESIZE={{ memcached_cache_size }}
-OPTIONS=""
+OPTIONS="-l {{ memcached_listen_address }}"


### PR DESCRIPTION
Adds the variable `memcached_listen_address` for overriding the listen address. Default: 0.0.0.0

Fixes #2
