### PR TITLE
Set ignoreerrors when using the sysctl module

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,7 @@
   when: ansible_os_family == "Debian"
 
 - name: Set the max open file descriptors 
-  sysctl: name=fs.file-max value={{ memcached_fs_file_max }} state=present
+  sysctl: name=fs.file-max value={{ memcached_fs_file_max }} state=present ignoreerrors=yes
 
 - name: start the memcached service
   service: name=memcached state=started enabled=yes


### PR DESCRIPTION
Without this, the play failed to run for me on CentOS 6.5 due to unknown keys.

Based on some of the comments and activity on the ansible project repo, this appears to be a common issue for people using the sysctl ansible module.

```
TASK: [memcached | Set the max open file descriptors] ************************* 
failed: [default] => {"failed": true}
msg: Failed to reload sysctl: net.ipv4.ip_forward = 0
net.ipv4.conf.default.rp_filter = 1
net.ipv4.conf.default.accept_source_route = 0
kernel.sysrq = 0
kernel.core_uses_pid = 1
net.ipv4.tcp_syncookies = 1
kernel.msgmnb = 65536
kernel.msgmax = 65536
kernel.shmmax = 68719476736
kernel.shmall = 4294967296
fs.file-max = 756024
error: "net.bridge.bridge-nf-call-ip6tables" is an unknown key
error: "net.bridge.bridge-nf-call-iptables" is an unknown key
error: "net.bridge.bridge-nf-call-arptables" is an unknown key
```
