### PR TITLE
Fix ignore_errors for sysctl

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -23,7 +23,8 @@
   when: ansible_os_family == "Debian"
 
 - name: Set the max open file descriptors 
-  sysctl: name=fs.file-max value={{ memcached_fs_file_max }} state=present ignoreerrors=yes
+  sysctl: name=fs.file-max value={{ memcached_fs_file_max }} state=present
+  ignore_errors: yes
 
 - name: start the memcached service
   service: name=memcached state=started enabled=yes


### PR DESCRIPTION
Required for lxc deployments
