### PR TITLE
Added optional kernel tuning

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,8 +1,21 @@
 ---
-
 memcached_port: 11211
 memcached_listen_address: 0.0.0.0
 memcached_max_conn: 1024
 memcached_cache_size: 64
 memcached_fs_file_max: 756024
-
+memcached_kernel_tuning: false
+memcached_kernel_params:
+  - { name: net.ipv4.ip_local_port_range, value: '"1024 65535"' }
+  - { name: net.ipv4.tcp_slow_start_after_idle, value: 0 }
+  - { name: net.core.somaxconn, value: 65535 }
+  - { name: net.core.netdev_max_backlog, value: 65536 }
+  - { name: net.ipv4.tcp_tw_reuse, value: 1 }
+  - { name: net.ipv4.tcp_fin_timeout, value: 15 }
+  - { name: net.ipv4.tcp_keepalive_time, value: 3600 }
+  - { name: net.ipv4.tcp_keepalive_intvl, value: 20 }
+  - { name: net.ipv4.tcp_keepalive_probes, value: 5 }
+  - { name: net.ipv4.tcp_max_syn_backlog, value: 12288 }
+  - { name: net.ipv4.tcp_synack_retries, value: 2 }
+  - { name: vm.nr_hugepages, value: 32 }
+  - { name: vm.hugetlb_shm_group, value: 1600 }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -28,3 +28,5 @@
 - name: start the memcached service
   service: name=memcached state=started enabled=yes
 
+- include: tune.yml
+  when: memcached_kernel_tuning|bool

--- a/tasks/tune.yml
+++ b/tasks/tune.yml
@@ -1,0 +1,8 @@
+---
+- name: Tuning /etc/sysctl.conf
+  sysctl: name={{ item.name }}
+          value={{ item.value }}
+          state=present
+  with_items: memcached_kernel_params
+  notify:
+    - restart memcached


### PR DESCRIPTION
We have found these tuning params useful with memcached.  Made these
optional and overridable.
