### PR TITLE
Fix some minor issues for porting it to 2.2.1

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -1,3 +1,5 @@
 ---
 - name: restart memcached
-  service: name=memcached state=restarted 
+  service:
+    name: memcached
+    state: restarted

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -23,4 +23,3 @@ galaxy_info:
   categories:
    - web
 dependencies: []
-  

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,7 +13,7 @@
     state: present
     update_cache: yes
   with_items: "{{memcached_ubuntu_pkgs}}"
-  environment: env
+  environment: "{{env}}"
   when: ansible_os_family == "Debian"
 
 - name: Copy the client configuration file

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,30 +1,45 @@
 ---
 
-- name: Install the memcached packages 
-  yum: name={{ item }} state=present
-  with_items: memcached_redhat_pkgs
+- name: Install the memcached packages
+  yum:
+    name: "{{item}}"
+    state: present
+  with_items: "{{memcached_redhat_pkgs}}"
   when: ansible_os_family == "RedHat"
 
-- name: Install the memcached packages 
-  apt: name={{ item }} state=present update_cache=yes
-  with_items: memcached_ubuntu_pkgs
+- name: Install the memcached packages
+  apt:
+    name: "{{item}}"
+    state: present
+    update_cache: yes
+  with_items: "{{memcached_ubuntu_pkgs}}"
   environment: env
   when: ansible_os_family == "Debian"
 
-- name: Copy the client configuration file 
-  template: src=memcached_redhat.j2 dest=/etc/sysconfig/memcached
-  notify: 
+- name: Copy the client configuration file
+  template:
+    src: memcached_redhat.j2
+    dest: /etc/sysconfig/memcached
+  notify:
    - restart memcached
   when: ansible_os_family == "RedHat"
 
-- name: Copy the client configuration file 
-  template: src=memcached_debian.j2 dest=/etc/memcached.conf
+- name: Copy the client configuration file
+  template:
+    src: memcached_debian.j2
+    dest: /etc/memcached.conf
   notify: restart memcached
   when: ansible_os_family == "Debian"
 
-- name: Set the max open file descriptors 
-  sysctl: name=fs.file-max value={{ memcached_fs_file_max }} state=present ignoreerrors=yes
+- name: Set the max open file descriptors
+  sysctl:
+    name: fs.file-max
+    value: "{{memcached_fs_file_max}}"
+    state: present
+    ignoreerrors: yes
 
 - name: start the memcached service
-  service: name=memcached state=started enabled=yes
-
+  service:
+    name: memcached
+    state: started
+    enabled: true


### PR DESCRIPTION
Some of the Ansible best-practices states that you should always use full YAML syntax instead of the `k=v` in your playbooks.
also there where some trailing whitespaces, with_ loops with bare vars and stuff like that.

with this changes the role should be able to pass the ansible-lint rules with no problemas